### PR TITLE
Fix bug in window message handling 

### DIFF
--- a/src/GL/Window/Window_Win32.cpp
+++ b/src/GL/Window/Window_Win32.cpp
@@ -335,7 +335,12 @@ namespace GL
 		} else {
 			window = reinterpret_cast<Window*>( GetWindowLong( hwnd, GWL_USERDATA ) );
 		
-			return window->WindowEvent( msg, wParam, lParam );
+			if( window != nullptr )
+			{
+				return window->WindowEvent( msg, wParam, lParam );
+			} else {
+				return DefWindowProc( hwnd, msg, wParam, lParam );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix a bug on windows (8?) where a WM_GETMINMAXINFO event is send befor
the WM_NCCREATE event resulting in a null pointer as a result of the
GetWindowLong( hwnd, GWL_USERDATA ) call. Solution: add a nullpointer
check befor calling a member function of window.
