### PR TITLE
Hide copy and assignment form some types, Remove passing enums by const reference

### DIFF
--- a/include/GL/GL/Context.hpp
+++ b/include/GL/GL/Context.hpp
@@ -111,6 +111,8 @@ namespace GL
 		friend class Window;
 		
 		Context();
+		Context( const Context& );
+		const Context& operator=( const Context& );
 
 		bool owned;
 

--- a/include/GL/GL/Program.hpp
+++ b/include/GL/GL/Program.hpp
@@ -87,6 +87,9 @@ namespace GL
 
 	private:
 		GLuint id;
+		
+		Program( const Program& );
+		const Program& operator=( const Program& );
 	};
 }
 

--- a/include/GL/GL/Shader.hpp
+++ b/include/GL/GL/Shader.hpp
@@ -83,6 +83,9 @@ namespace GL
 
 	private:
 		GLuint id;
+		
+		Shader( const Shader& );
+		const Shader& operator=( const Shader& );
 	};
 }
 

--- a/include/GL/GL/Texture.hpp
+++ b/include/GL/GL/Texture.hpp
@@ -194,25 +194,28 @@ namespace GL
 	{
 	public:
 		Texture();
-		Texture( const Image& image, const InternalFormat::internal_format_t& internalFormat = InternalFormat::RGBA );
+		Texture( const Image& image, InternalFormat::internal_format_t internalFormat = InternalFormat::RGBA );
 
 		~Texture();
 
 		operator GLuint() const;
 		
-		void Image2D( const GLvoid* data, const DataType::data_type_t& type, const Format::format_t& format, uint width, uint height, const InternalFormat::internal_format_t& internalFormat );
+		void Image2D( const GLvoid* data, DataType::data_type_t type, Format::format_t format, uint width, uint height, InternalFormat::internal_format_t internalFormat );
 		
-		void SetWrapping( const Wrapping::wrapping_t& s );
-		void SetWrapping( const Wrapping::wrapping_t& s, const Wrapping::wrapping_t& t );
-		void SetWrapping( const Wrapping::wrapping_t& s, const Wrapping::wrapping_t& t, const Wrapping::wrapping_t& r );
+		void SetWrapping( Wrapping::wrapping_t s );
+		void SetWrapping( Wrapping::wrapping_t s, Wrapping::wrapping_t t );
+		void SetWrapping( Wrapping::wrapping_t s, Wrapping::wrapping_t t, Wrapping::wrapping_t r );
 
-		void SetFilters( const Filter::filter_t& min, const Filter::filter_t& mag );
+		void SetFilters( Filter::filter_t min, Filter::filter_t mag );
 		void SetBorderColor( const Color& color );
 
 		void GenerateMipmaps();
 
 	private:
 		GLuint id;
+
+		Texture( const Texture& );
+		const Texture& operator=( const Texture& );
 	};
 }
 

--- a/include/GL/GL/VertexArray.hpp
+++ b/include/GL/GL/VertexArray.hpp
@@ -41,12 +41,15 @@ namespace GL
 
 		operator GLuint() const;
 
-		void BindAttribute( const Attribute& attribute, const VertexBuffer& buffer, const Type::type_t& type, uint count, uint stride, intptr_t offset );
+		void BindAttribute( const Attribute& attribute, const VertexBuffer& buffer, Type::type_t type, uint count, uint stride, intptr_t offset );
 
 		void BindElements( const VertexBuffer& elements );
 
 	private:
 		GLuint id;
+		
+		VertexArray( const VertexArray& );
+		const VertexArray& operator=( const VertexArray& );
 	};
 }
 

--- a/include/GL/GL/VertexBuffer.hpp
+++ b/include/GL/GL/VertexBuffer.hpp
@@ -66,6 +66,9 @@ namespace GL
 
 	private:
 		GLuint id;
+		
+		VertexBuffer( const VertexBuffer& );
+		const VertexBuffer& operator=( const VertexBuffer& );
 	};
 }
 

--- a/include/GL/Util/ByteBuffer.hpp
+++ b/include/GL/Util/ByteBuffer.hpp
@@ -111,6 +111,9 @@ namespace GL
 		uint length;
 		uint ptr;
 		bool littleEndian;
+
+		ByteReader( const ByteReader& ) { }
+		const ByteReader& operator=( const ByteReader& ) { }
 	};
 
 	/*

--- a/include/GL/Util/Image.hpp
+++ b/include/GL/Util/Image.hpp
@@ -91,6 +91,9 @@ namespace GL
 	private:
 		Color* image;
 		ushort width, height;
+
+		Image( const Image& ) { }
+		const Image& operator=( const Image& ) { }
 		
 		void LoadBMP( ByteReader& data );
 		void SaveBMP( const std::string& filename );

--- a/include/GL/Window/Window.hpp
+++ b/include/GL/Window/Window.hpp
@@ -119,7 +119,10 @@ namespace GL
 		void EnableFullscreen( bool enabled, int width = 0, int height = 0 );
 		void WindowEvent( const XEvent& event );
 		static Bool CheckEvent( Display*, XEvent* event, XPointer userData );
-#endif
+#endif		
+
+		Window( const Window& ) { }
+		const Window& operator=( const Window& ) { }
 
 		Key::key_t TranslateKey( uint code );
 	};

--- a/src/GL/GL/Texture.cpp
+++ b/src/GL/GL/Texture.cpp
@@ -31,7 +31,7 @@ namespace GL
 		glGenTextures( 1, &id );
 	}
 
-	Texture::Texture( const Image& image, const InternalFormat::internal_format_t& internalFormat )
+	Texture::Texture( const Image& image, InternalFormat::internal_format_t internalFormat )
 	{
 		PUSHSTATE()
 
@@ -60,7 +60,7 @@ namespace GL
 		return id;
 	}
 
-	void Texture::Image2D( const GLvoid* data, const DataType::data_type_t& type, const Format::format_t& format, uint width, uint height, const InternalFormat::internal_format_t& internalFormat )
+	void Texture::Image2D( const GLvoid* data, DataType::data_type_t type, Format::format_t format, uint width, uint height, InternalFormat::internal_format_t internalFormat )
 	{
 		PUSHSTATE()
 
@@ -70,7 +70,7 @@ namespace GL
 		POPSTATE()
 	}
 
-	void Texture::SetWrapping( const Wrapping::wrapping_t& s )
+	void Texture::SetWrapping( Wrapping::wrapping_t s )
 	{
 		PUSHSTATE()
 
@@ -82,7 +82,7 @@ namespace GL
 		POPSTATE()
 	}
 
-	void Texture::SetWrapping( const Wrapping::wrapping_t& s, const Wrapping::wrapping_t& t )
+	void Texture::SetWrapping( Wrapping::wrapping_t s, Wrapping::wrapping_t t )
 	{
 		PUSHSTATE()
 
@@ -95,7 +95,7 @@ namespace GL
 		POPSTATE()
 	}
 
-	void Texture::SetWrapping( const Wrapping::wrapping_t& s, const Wrapping::wrapping_t& t, const Wrapping::wrapping_t& r )
+	void Texture::SetWrapping( Wrapping::wrapping_t s, Wrapping::wrapping_t t, Wrapping::wrapping_t r )
 	{
 		PUSHSTATE()
 
@@ -107,7 +107,7 @@ namespace GL
 		POPSTATE()
 	}
 
-	void Texture::SetFilters( const Filter::filter_t& min, const Filter::filter_t& mag )
+	void Texture::SetFilters( Filter::filter_t min, Filter::filter_t mag )
 	{
 		PUSHSTATE()
 

--- a/src/GL/GL/VertexArray.cpp
+++ b/src/GL/GL/VertexArray.cpp
@@ -38,7 +38,7 @@ namespace GL
 		return id;
 	}
 
-	void VertexArray::BindAttribute( const Attribute& attribute, const VertexBuffer& buffer, const Type::type_t& type, uint count, uint stride, intptr_t offset )
+	void VertexArray::BindAttribute( const Attribute& attribute, const VertexBuffer& buffer, Type::type_t type, uint count, uint stride, intptr_t offset )
 	{
 		glBindVertexArray( id );
 		glBindBuffer( GL_ARRAY_BUFFER, buffer );


### PR DESCRIPTION
Hiding the copy constructor and assignment operator stops developers
from setting types into undefined states. They can still use pointers or
smart pointers to pass the types (like storing textures in a
vector/map). It would probably make sense to implement to C++11 move
constructor to allow moving the ownership of data between objects. Like
moving the texture id from one to another object and leaving an empty
object. But this need to be in an #if for non C++11 compilers.

Passing by const reference doesn't make sense for enums
