### PR TITLE
shorthand form for GL::Program::SetUniform

### DIFF
--- a/include/GL/GL/Program.hpp
+++ b/include/GL/GL/Program.hpp
@@ -79,6 +79,18 @@ namespace GL
 		Attribute GetAttribute( const std::string& name );
 		Uniform GetUniform( const std::string& name );
 
+		template <typename T>
+		void SetUniform( const std::string& name, const T& value )
+		{
+			SetUniform( GetUniform( name ), value );
+		}
+
+		template <typename T>
+		void SetUniform( const std::string& name, const T* values, uint count)
+		{
+			SetUniform( GetUniform( name ), values, count );
+		}
+
 		void SetUniform( const Uniform& uniform, int value );
 		void SetUniform( const Uniform& uniform, float value );
 		void SetUniform( const Uniform& uniform, const Vec2& value );

--- a/samples/ShadowMapping/main.cpp
+++ b/samples/ShadowMapping/main.cpp
@@ -88,8 +88,8 @@ int main()
 	normalVAO.BindAttribute( normalProgram.GetAttribute( "normal" ), sceneBuffer, GL::Type::Float, 3, sizeof(float) * 8, sizeof(float) * 3 );
 	normalVAO.BindAttribute( normalProgram.GetAttribute( "texcoord" ), sceneBuffer, GL::Type::Float, 2, sizeof(float) * 8, sizeof(float) * 6 );
 
-	normalProgram.SetUniform( normalProgram.GetUniform( "texCrate" ), 0 );
-	normalProgram.SetUniform( normalProgram.GetUniform( "texLight" ), 1 );
+	normalProgram.SetUniform( "texCrate", 0 );
+	normalProgram.SetUniform( "texLight", 1 );
 
 	// Prepare rendering
 	GL::Framebuffer lightFBO( 4096, 4096 );
@@ -134,7 +134,7 @@ int main()
 		GL::Mat4 view = GL::Mat4::LookAt( lightPos, GL::Vec3( 0, 0, 0 ), GL::Vec3( 0, 0, 1 ) );
 		GL::Mat4 proj = GL::Mat4::Perspective( GL::Rad( 45 ), 1.0, 1.0f, 10.0f );
 		GL::Mat4 lightTrans = proj * view;
-		lightProgram.SetUniform( lightProgram.GetUniform( "trans" ), lightTrans );
+		lightProgram.SetUniform( "trans", lightTrans );
 		
 		gl.DrawArrays( lightVAO, GL::Primitive::Triangles, 0, sceneMesh.VertexCount() );
 
@@ -147,9 +147,9 @@ int main()
 		view = GL::Mat4::LookAt( GL::Vec3( 4, 3.8, 3.2 ), GL::Vec3( 0, 0, -0.2 ), GL::Vec3( 0, 0, 1 ) );
 		view.RotateZ( yaw );
 		proj = GL::Mat4::Perspective( GL::Rad( 45 ), 4.0f/3.0f, 1.0f, 10.0f );
-		normalProgram.SetUniform( normalProgram.GetUniform("trans"), proj * view );
-		normalProgram.SetUniform( normalProgram.GetUniform("lightTrans"), lightTrans );
-		normalProgram.SetUniform( normalProgram.GetUniform("lightPos"), lightPos );
+		normalProgram.SetUniform( "trans", proj * view );
+		normalProgram.SetUniform( "lightTrans", lightTrans );
+		normalProgram.SetUniform( "lightPos", lightPos );
 		
 		gl.DrawArrays( normalVAO, GL::Primitive::Triangles, 0, sceneMesh.VertexCount() );
 

--- a/samples/StencilReflection/main.cpp
+++ b/samples/StencilReflection/main.cpp
@@ -76,12 +76,12 @@ int main()
 		// Set up transformations
 		GL::Mat4 model;
 		model.RotateZ( gl.Time() );
-		program.SetUniform( program.GetUniform( "trans" ), proj * view * model );
+		program.SetUniform( "trans", proj * view * model );
 
 		// Draw normal tank
 		glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
-		program.SetUniform( program.GetUniform( "tex" ), 0 );
-		program.SetUniform( program.GetUniform( "transparency" ), 1.0f );
+		program.SetUniform( "tex", 0 );
+		program.SetUniform( "transparency", 1.0f );
 		gl.DrawArrays( vaoTank, GL::Primitive::Triangles, 0, meshTank.VertexCount() );
 
 		// Draw platform
@@ -92,20 +92,20 @@ int main()
 		gl.StencilMask( true );
 		gl.Clear( GL::Buffer::Stencil );
 
-		program.SetUniform( program.GetUniform( "tex" ), 1 );
-		program.SetUniform( program.GetUniform( "transparency" ), 1.0f );
+		program.SetUniform( "tex", 1 );
+		program.SetUniform( "transparency", 1.0f );
 		gl.DrawArrays( vaoPlatform, GL::Primitive::Triangles, 0, meshPlatform.VertexCount() );
 		
 		// Draw upside down tank
 		model.Scale( GL::Vec3( 1, 1, -1 ) );
-		program.SetUniform( program.GetUniform( "trans" ), proj * view * model );
+		program.SetUniform( "trans", proj * view * model );
 
 		gl.DepthMask( true );
 		gl.StencilMask( false );
 		gl.StencilFunc( GL::TestFunction::Equal, 1 );
 
-		program.SetUniform( program.GetUniform( "tex" ), 0 );
-		program.SetUniform( program.GetUniform( "transparency" ), 0.4f );
+		program.SetUniform( "tex", 0 );
+		program.SetUniform( "transparency", 0.4f );
 		gl.DrawArrays( vaoTank, GL::Primitive::Triangles, 0, meshTank.VertexCount() );
 
 		gl.Disable( GL::Capability::StencilTest );


### PR DESCRIPTION
I noticed that a call to `SetUniform` invariably gets a `GetUniform` call on the same program in the first argument position, so I introduced a shorthand form that does the call for the user.
