### PR TITLE
Fixes Shadowmapping sample where shadowmap sampler extracts z and not…

### DIFF
--- a/samples/ShadowMapping/main.cpp
+++ b/samples/ShadowMapping/main.cpp
@@ -70,7 +70,7 @@ int main()
 			lightCoord.y = ( lightCoord.y + 1.0 ) / 2.0;
 			lightCoord.z = ( lightCoord.z + 1.0 ) / 2.0;
 
-			float lightDepth = texture( texLight, lightCoord.xy ).z;
+			float lightDepth = texture( texLight, lightCoord.xy ).x;
 			
 			// Determine if fragment is in shadow or determine diffuse lighting
 			float diffuse = max( dot( Normal, normalize( lightPos - Pos ) ), 0 ) * 0.8 + 0.2;


### PR DESCRIPTION
For the Shadowmapping sample, the sampler in the NormalFrag fragment shader is extracting incorrect 'z' component for lightDepth lookup.  This fix makes it correctly extract the 'x' component.