### PR TITLE
Update Extensions.cpp

### DIFF
--- a/src/GL/GL/Extensions.cpp
+++ b/src/GL/GL/Extensions.cpp
@@ -126,7 +126,7 @@ namespace GL
 	inline void* LoadExtension( const char* name )
 	{
 #if defined( OOGL_PLATFORM_WINDOWS )
-		return wglGetProcAddress( name );
+		return (void*)wglGetProcAddress( name );
 #elif defined( OOGL_PLATFORM_LINUX )
 		return (void*)glXGetProcAddress( (const GLubyte*)name );
 #endif


### PR DESCRIPTION
Make was failing on Windows 10 giving the below error without the following cast.

 error: invalid conversion from 'PROC' {aka 'long long int (*)()'} to 'void*' [-fpermissive]
   return wglGetProcAddress( name )