### PR TITLE
Fix small error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ int main()
 
 		gl.Clear();
 
-		gl.DrawArrays(vao, GL::Primitive::Triangle, 0, 3);
+		gl.DrawArrays(vao, GL::Primitive::Triangles, 0, 3);
 
 		window.Present();
 	}


### PR DESCRIPTION
It seems that in the newest version its called Triangles as opposed to Triangle